### PR TITLE
Add Package.NewVersion function

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,4 @@
-all: alpm-installed alpm-search
+all: alpm-installed alpm-search alpm-updates
 
 alpm-installed: installed.go
 	go build -x -o $@ $<
@@ -6,5 +6,8 @@ alpm-installed: installed.go
 alpm-search: search.go
 	go build -x -o $@ $<
 
+alpm-updates: updates.go
+	go build -x -o $@ $<
+
 clean:
-	rm -f alpm-installed alpm-search
+	rm -f alpm-installed alpm-search alpm-updates

--- a/examples/updates.go
+++ b/examples/updates.go
@@ -1,0 +1,78 @@
+//
+//
+// Copyright (c) 2013 The go-alpm Authors
+//
+// MIT Licensed. See LICENSE for details.
+
+package main
+
+import (
+	"github.com/demizer/go-alpm"
+	"fmt"
+    "log"
+    "os"
+)
+
+func human(size int64) string {
+    floatsize := float32(size)
+    units := [...]string{"", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"}
+    for _, unit := range units {
+        if floatsize < 1024 {
+            return fmt.Sprintf("%.1f %sB", floatsize, unit)
+        }
+        floatsize /= 1024
+    }
+    return fmt.Sprintf("%d%s", size, "B")
+}
+
+func upgrades(h *alpm.Handle) ([]alpm.Package, error) {
+	localDb, err := h.LocalDb()
+    if err != nil {
+        return nil, err
+    }
+
+    syncDbs, err := h.SyncDbs()
+    if err != nil {
+        return nil, err
+    }
+
+    slice := []alpm.Package{}
+	for _, pkg := range localDb.PkgCache().Slice() {
+        newPkg := pkg.NewVersion(syncDbs);
+        if newPkg != nil {
+            slice = append(slice, *newPkg)
+        }
+    }
+    return slice, nil
+}
+
+func main() {
+
+    file, err := os.Open("/etc/pacman.conf")
+    if err != nil {
+		log.Fatalln(err)
+    }
+    conf, err := alpm.ParseConfig(file)
+    if err != nil {
+		log.Fatalln(err)
+    }
+
+	h, err := conf.CreateHandle()
+	defer h.Release()
+    if err != nil {
+		log.Fatalln(err)
+    }
+
+    upgrades, err := upgrades(h)
+    if err != nil {
+		log.Fatalln(err)
+    }
+
+    var size int64 = 0
+    for _, pkg := range upgrades {
+        size += pkg.Size()
+        fmt.Printf("%s %s -> %s\n", pkg.Name(), pkg.Version(),
+            pkg.Version())
+    }
+    fmt.Printf("Total Download Size: %s\n", human(size))
+}

--- a/package.go
+++ b/package.go
@@ -178,3 +178,12 @@ func (pkg Package) ComputeRequiredBy() []string {
 	}
 	return requiredby
 }
+
+func (pkg Package) NewVersion(l DbList) *Package {
+	ptr := C.alpm_sync_newversion(pkg.pmpkg,
+		(*C.alpm_list_t)(unsafe.Pointer(l.list)))
+	if ptr == nil {
+		return nil
+	}
+	return &Package{ptr, l.handle}
+}


### PR DESCRIPTION
Search a list of databases for a new version of the given package. Wrapper
around alpm_sync_newversion. `examples/updates.go` shows how to use it to
implement something similar to `pacman -Qu`.